### PR TITLE
Enable resuming watching based on watching history

### DIFF
--- a/lib/bean/anime/anime_card.dart
+++ b/lib/bean/anime/anime_card.dart
@@ -1,9 +1,11 @@
 import 'dart:io';
 
+import 'package:oneanime/bean/anime/anime_history.dart';
 import 'package:oneanime/bean/anime/anime_info.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:oneanime/pages/menu/side_menu.dart';
+import 'package:oneanime/pages/player/player_controller.dart';
 import 'package:oneanime/pages/popular/popular_controller.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
 import 'package:oneanime/pages/menu/menu.dart';
@@ -49,7 +51,12 @@ class _AnimeInfoCardState extends State<AnimeInfoCard> {
       child: InkWell(
         onTap: () async {
           SmartDialog.showLoading(msg: '获取中');
-          historyController.updateHistory(widget.info.link ?? 0);
+          AnimeHistory? history = historyController.lookupHistory(widget.info.link ?? 0);
+          if (history == null) {
+            historyController.updateHistory(widget.info.link ?? 0, 0);
+          } else {
+            historyController.updateHistory(widget.info.link ?? 0, history.offset ?? 0);
+          }
           try {
             debugPrint(
                 'AnimeButton被按下 对应链接为 https://anime1.me/?cat=${widget.info.link}');
@@ -73,6 +80,8 @@ class _AnimeInfoCardState extends State<AnimeInfoCard> {
             SmartDialog.showToast('上次观看到第 ${widget.info.progress} 话');
           }
           videoController.from = '/tab/' + widget.type + '/';
+          videoController.link = widget.info.link!;
+          videoController.offset = history?.offset ?? 0;
           navigationBarState = Platform.isWindows
               ? Provider.of<SideNavigationBarState>(context, listen: false)
               : Provider.of<NavigationBarState>(context, listen: false);

--- a/lib/bean/anime/anime_history.dart
+++ b/lib/bean/anime/anime_history.dart
@@ -7,16 +7,20 @@ class AnimeHistory extends HiveObject {
   int? link;
   @HiveField(1)
   int? time;
+  @HiveField(2)
+  int? offset;
 
   AnimeHistory({
     this.link,
     this.time,
+    this.offset,
   });
 
   AnimeHistory.fromJson(Map<String, dynamic>? json) {
     if (json == null) return;
     link = json['link'];
     time = json['time'];
+    offset = json['offset'];
   }
 }
 
@@ -26,15 +30,20 @@ class AnimeHistoryAdapter extends TypeAdapter<AnimeHistory> {
 
   @override
   AnimeHistory read(BinaryReader reader) {
-    return AnimeHistory(
+    var history = AnimeHistory(
       link: reader.readInt(),
       time: reader.readInt(),
     );
+    if (reader.availableBytes > 0) {
+      history.offset = reader.readInt();
+    }
+    return history;
   }
 
   @override
   void write(BinaryWriter writer, AnimeHistory obj) {
     writer.writeInt(obj.link ?? 19951);
     writer.writeInt(obj.time ?? 0);
+    writer.writeInt(obj.offset ?? 0);
   }
 }

--- a/lib/pages/history/history_controller.dart
+++ b/lib/pages/history/history_controller.dart
@@ -52,7 +52,7 @@ abstract class _HistoryController with Store {
     updateData();
   }
 
-  Future updateHistory(int link) async {
+  Future updateHistory(int link, int offset) async {
     privateMode = setting.get(SettingBoxKey.privateMode, defaultValue: false);
     if (privateMode) {
       return;
@@ -74,8 +74,10 @@ abstract class _HistoryController with Store {
         await GStorage.history.addAll(history);
       }
     }
-    newRecord = AnimeHistory.fromJson({"link": link, "time": time});
+    newRecord = AnimeHistory.fromJson({"link": link, "time": time, "offset": offset});
+    debugPrint('更新历史记录：link: ${link}, time: ${time}, offset: ${offset}');
     await GStorage.history.add(newRecord);
+    history = GStorage.history.values.toList();
   }
 
   Future deleteHistory(int link) async {
@@ -107,6 +109,16 @@ abstract class _HistoryController with Store {
     }
     await GStorage.history.clear();
     await GStorage.history.addAll(history);
+  }
+
+  AnimeHistory? lookupHistory(int link) {
+    AnimeHistory? ret;
+    history.asMap().forEach((key, value) {
+      if (value.link == link) {
+        ret = value;
+      }
+    });
+    return ret;
   }
 
   Future clearHistory() async {

--- a/lib/pages/player/player_controller.g.dart
+++ b/lib/pages/player/player_controller.g.dart
@@ -33,8 +33,8 @@ mixin _$PlayerController on _PlayerController, Store {
       AsyncAction('_PlayerController.init', context: context);
 
   @override
-  Future<dynamic> init() {
-    return _$initAsyncAction.run(() => super.init());
+  Future<dynamic> init(int offset) {
+    return _$initAsyncAction.run(() => super.init(offset));
   }
 
   @override

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -78,6 +78,8 @@ abstract class _VideoController with Store {
   String videoCookie = '';
   String title = '';
   String from = '/tab/popular/';
+  int link = 0;
+  int offset = 0;
 
   Box setting = GStorage.setting;
 
@@ -112,7 +114,7 @@ abstract class _VideoController with Store {
       debugPrint(e.toString());
     }
     playerSpeed = 1.0;
-    await playerController.init();
+    await playerController.init(0);
   }
 
   Future getAniDanmakuList(String title) async {

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_modular/flutter_modular.dart';
 import 'package:flutter_smart_dialog/flutter_smart_dialog.dart';
+import 'package:oneanime/pages/history/history_controller.dart';
 import 'package:oneanime/pages/video/video_controller.dart';
 import 'package:oneanime/pages/player/player_controller.dart';
 import 'package:oneanime/pages/player/player_item.dart';
@@ -36,6 +37,7 @@ class _VideoPageState extends State<VideoPage> with WindowListener {
   final FocusNode _focusNode = FocusNode();
   final VideoController videoController = Modular.get<VideoController>();
   final PlayerController playerController = Modular.get<PlayerController>();
+  final HistoryController historyController = Modular.get<HistoryController>();
 
   // 弹幕
   final _danmuKey = GlobalKey();
@@ -69,7 +71,8 @@ class _VideoPageState extends State<VideoPage> with WindowListener {
     videoController.playerSpeed = 1.0;
     playerController.videoUrl = videoController.videoUrl;
     playerController.videoCookie = videoController.videoCookie;
-    playerController.init();
+    playerController.init(videoController.offset);
+    videoController.offset = 0;
     try {
       videoController.danDanmakus.clear();
       videoController.getDanDanmaku(
@@ -93,6 +96,7 @@ class _VideoPageState extends State<VideoPage> with WindowListener {
     } catch (e) {
       debugPrint(e.toString());
     }
+    historyController.updateHistory(videoController.link, videoController.currentPosition.inSeconds);
     windowManager.removeListener(this);
     playerController.dispose();
     super.dispose();


### PR DESCRIPTION
## Description

为`AnimeHistory`增加了一个field存储观看时长信息，并根据此信息在进入播放界面时恢复之前的观看进度。

## Others

1. 第一次写dart，基本上就是对着代码照猫画虎写的，merge前请多注意bug等。
2. `HistoryController`似乎有一些bug。截至提交PR时已经有一个commit ahead of me修复相关bug（而且与这个PR冲突），但应该仍存在bug。最近有时间了的话要是还没修我再修一下。
3. `media_kit`库在最近的更新中加入了设定视频起始时间点的功能，但还未release。如果oneAnime未来提升dependency版本可以改一下。