### PR TITLE
Fix: HistoryController in history page and that in video page referen…

### DIFF
--- a/lib/pages/history/history_controller.dart
+++ b/lib/pages/history/history_controller.dart
@@ -57,6 +57,7 @@ abstract class _HistoryController with Store {
     if (privateMode) {
       return;
     }
+    history = GStorage.history.values.toList();
     int? deleteKey;
     AnimeHistory newRecord;
     int time = DateTime.now().millisecondsSinceEpoch ~/ 1000;
@@ -77,7 +78,7 @@ abstract class _HistoryController with Store {
     newRecord = AnimeHistory.fromJson({"link": link, "time": time, "offset": offset});
     debugPrint('更新历史记录：link: ${link}, time: ${time}, offset: ${offset}');
     await GStorage.history.add(newRecord);
-    history = GStorage.history.values.toList();
+    history.add(newRecord);
   }
 
   Future deleteHistory(int link) async {
@@ -86,6 +87,7 @@ abstract class _HistoryController with Store {
     //   await GStorage.history.clear();
     //   return;
     // }
+    history = GStorage.history.values.toList();
     int? deleteKey;
     history.asMap().forEach((key, value) {
       if (value.link == link) {
@@ -113,6 +115,7 @@ abstract class _HistoryController with Store {
 
   AnimeHistory? lookupHistory(int link) {
     AnimeHistory? ret;
+    history = GStorage.history.values.toList();
     history.asMap().forEach((key, value) {
       if (value.link == link) {
         ret = value;


### PR DESCRIPTION
## Description

修复了由于anime card中的`historyController`与video page中`historyController`分别引用了两个不同的`HistoryController` class实例，从而导致两个实例中`history` list不同步的问题。这个问题会导致断点播放的错误。

PS：或许可以考虑直接操作`GStorage.history`，不操作history的list？