### PR TITLE
Default danmaku switch

### DIFF
--- a/lib/pages/settings/danmaku_settings.dart
+++ b/lib/pages/settings/danmaku_settings.dart
@@ -77,6 +77,14 @@ class _DanmakuSettingsPageState extends State<DanmakuSettingsPage> {
           children: [
             const InkWell(
               child: SetSwitchItem(
+                title: '默认开启',
+                subTitle: '默认是否随视频播放弹幕',
+                setKey: SettingBoxKey.danmakuEnabledByDefault,
+                defaultVal: false,
+              ),
+            ),
+            const InkWell(
+              child: SetSwitchItem(
                 title: '精准匹配',
                 setKey: SettingBoxKey.danmakuEnhance,
                 defaultVal: true,

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -49,7 +49,8 @@ abstract class _VideoController with Store {
 
   // 弹幕开关
   @observable
-  bool danmakuOn = false;
+  bool danmakuOn = GStorage.setting
+      .get(SettingBoxKey.danmakuEnabledByDefault, defaultValue: false);
 
   // 界面管理
   @observable

--- a/lib/pages/video/video_controller.dart
+++ b/lib/pages/video/video_controller.dart
@@ -49,8 +49,7 @@ abstract class _VideoController with Store {
 
   // 弹幕开关
   @observable
-  bool danmakuOn = GStorage.setting
-      .get(SettingBoxKey.danmakuEnabledByDefault, defaultValue: false);
+  bool danmakuOn = false;
 
   // 界面管理
   @observable

--- a/lib/pages/video/video_page.dart
+++ b/lib/pages/video/video_page.dart
@@ -98,6 +98,8 @@ class _VideoPageState extends State<VideoPage> with WindowListener {
 
   void init() async {
     videoController.playerSpeed = 1.0;
+    videoController.danmakuOn =
+        setting.get(SettingBoxKey.danmakuEnabledByDefault, defaultValue: false);
     playerController.videoUrl = videoController.videoUrl;
     playerController.videoCookie = videoController.videoCookie;
     await playerController.init(videoController.offset);

--- a/lib/utils/storage.dart
+++ b/lib/utils/storage.dart
@@ -72,6 +72,7 @@ class SettingBoxKey {
       danmakuScroll = 'danmakuScroll',
       danmakuBottom = 'danmakuBottom',
       danmakuArea = 'danmakuArea',
+      danmakuEnabledByDefault = 'danmakuEnabledByDefault',
       themeMode = 'themeMode',
       themeColor = 'themeColor',
       privateMode = 'privateMode',


### PR DESCRIPTION
功能：在“弹幕设置”里面增加一个“默认开启”的选项，开启之后进入视频播放页面时会自动打开弹幕开关。

更新：在 videoPage 初始化时获取了 `danmakuEnabledByDefault` 的值，移除了 `SetSwitchItem` 的 `needReboot: true`。